### PR TITLE
Fixes installing external scripts from git

### DIFF
--- a/hubot-slack/Dockerfile
+++ b/hubot-slack/Dockerfile
@@ -8,6 +8,8 @@ USER hubot
 
 WORKDIR /home/hubot
 
+RUN npm install underscore
+
 ENV BOT_NAME "bot"
 ENV BOT_OWNER "No owner specified"
 ENV BOT_DESC "Hubot with slack adapter"
@@ -19,6 +21,6 @@ RUN yo hubot --owner="$BOT_OWNER" --name="$BOT_NAME" --description="$BOT_DESC" -
 	sed -i /redis-brain/d ./external-scripts.json && \
 	npm install hubot-scripts hubot-slack@^3.0.0
 
-CMD node -e "console.log(JSON.stringify('$EXTERNAL_SCRIPTS'.split(',')))" > external-scripts.json && \
+CMD node -e "console.log(JSON.stringify(require('underscore').map('$EXTERNAL_SCRIPTS'.split(','), function(s) { return s.split('@')[0]; })))" > external-scripts.json && \
 	npm install $(node -e "console.log('$EXTERNAL_SCRIPTS'.split(',').join(' '))") && \
 	bin/hubot -n $BOT_NAME -a slack

--- a/hubot-slack/Dockerfile
+++ b/hubot-slack/Dockerfile
@@ -1,14 +1,12 @@
 FROM node:0.12.4
 MAINTAINER Krzysztof Skoracki <krzysztof.skoracki@unit9.com>
 
-RUN npm install -g coffee-script yo generator-hubot  &&  \
+RUN npm install -g underscore coffee-script yo generator-hubot  &&  \
 	useradd hubot -m
 
 USER hubot
 
 WORKDIR /home/hubot
-
-RUN npm install underscore
 
 ENV BOT_NAME "bot"
 ENV BOT_OWNER "No owner specified"


### PR DESCRIPTION
When using the "package@url" form, npm would happily accept it and
install from some external source. However Hubot will complain about
garbage. Fix is to put only the base package name (without the "@url"
part) in `external-scripts.json`.
