### PR TITLE
Support for /etc/rc.local; cleanup Makefile

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -12,6 +12,12 @@ run apt-get update && \
             && \
     rm -rf /var/cache/apt
 
-add https://github.com/peterbourgon/runsvinit/releases/download/v2.0.0/runsvinit-linux-amd64.tgz /tmp/runsvinit.tgz
-run cd /sbin && tar zxf /tmp/runsvinit.tgz && rm /tmp/runsvinit.tgz
-cmd ["/sbin/runsvinit"]
+run curl -fsSL -o /tmp/runsvinit.tgz \
+    https://github.com/peterbourgon/runsvinit/releases/download/v2.0.0/runsvinit-linux-amd64.tgz \
+    && sha256sum /tmp/runsvinit.tgz \
+    && cd /sbin \
+    && tar zxf /tmp/runsvinit.tgz \
+    && chown root:root /sbin/runsvinit \
+    && rm /tmp/runsvinit.tgz
+add rc rc.local /etc/
+cmd ["/etc/rc"]

--- a/base/Makefile
+++ b/base/Makefile
@@ -1,19 +1,25 @@
+IMAGE    := unit9/base
+VERSION  ?= latest
+NAME     ?= base
+
+
 all: build
 
-build: docker-init
-	@docker build -t unit9/base:latest .
-
-run: build
-	@docker run --rm -ti unit9/base
-
-shell: build
-	@docker run --rm -ti unit9/base bash
+build:
+	@docker build -t ${IMAGE}:${VERSION} .
 
 clean:
-	@- rm -f docker-init
+	@docker rmi ${IMAGE}:${VERSION}
+
+run: build
+	@docker run --rm -ti -P \
+		--name ${NAME} ${IMAGE}
+
+shell: build
+	@docker run --rm -ti \
+		${IMAGE} bash
 
 push:
-	@docker push unit9/base:latest
+	@docker push ${IMAGE}:${VERSION}
 
-
-.PHONY: all build run shell clean push
+.PHONY: all build run shell push

--- a/base/rc
+++ b/base/rc
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+echo "Running /etc/rc.local"
+/etc/rc.local
+echo "Running /sbin/runsvinit"
+exec /sbin/runsvinit

--- a/base/rc.local
+++ b/base/rc.local
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+# This script is executed during container boot. Put any global
+# initialisation or self-tests here. Make sure that the script will
+# "exit 0" on success or any other value on error.
+exit 0

--- a/base/readme.md
+++ b/base/readme.md
@@ -27,6 +27,8 @@ Source on [Github][]: <https://github.com/unit9/docker-base>
 - `Makefile` for easy builds and uploads:
     - `make build` to build
     - `make push` to push to Docker Hub
+    - `make shell` gives you a shell in the (ephemeral) container
+- Support for `/etc/rc.local` to initialise & self-check the container
 
 ## Using with your `Dockerfile`
 
@@ -41,6 +43,7 @@ run apt-get update && \
     rm -rf /var/cache/apt
 
 add run_my_stuff /etc/service/run_my_stuff/run
+add rc.local /etc/rc.local
 
 volume /data/run_my_stuff
 expose 1234
@@ -70,6 +73,21 @@ EOF
 echo >&2 "Starting my stuff"
 exec /usr/bin/my-stuff --config /etc/my_stuff.conf
 ```
+
+Inside of `rc.local`, is another simple shell script, which can
+perform any one-off initialisation tasks or self-checks:
+
+```
+#!/bin/sh
+set -eux
+test -f /var/www/html/index.html
+lighttpd -t -f /etc/lighttpd/lighttpd.conf
+exit 0
+```
+
+Make sure the script returns a non-zero code on an error. Your
+container will exit upon failure - this is useful to e.g. stop a bad
+deployment before the rolling update brings everything down.
 
 ## License
 


### PR DESCRIPTION
- Added support for `/etc/rc.local` - can now run one-off self-tests on container boot
- Changed to use curl instead of add with URL - https://github.com/docker/docker/issues/15717
- Cleaned up Makefile
- Updated docs
