### PR TITLE
Feature/inspector

### DIFF
--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -1,0 +1,16 @@
+from unit9/base:latest
+maintainer Kamil Cholewinski <kamil.cholewinski@unit9.com>
+
+run apt-key adv \
+    --keyserver hkp://ha.pool.sks-keyservers.net:80 \
+    --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+run echo 'deb https://apt.dockerproject.org/repo debian-jessie main' \
+     > /etc/apt/sources.list.d/docker.list
+run apt-get update && \
+    apt-get dist-upgrade --yes && \
+    apt-get install --no-install-recommends --yes \
+            docker-engine \
+            && \
+    rm -rf /var/cache/apt /var/lib/apt/lists/
+
+add rc.local /etc/rc.local

--- a/dind/rc.local
+++ b/dind/rc.local
@@ -2,6 +2,3 @@
 set -eu
 gid=$(ls -ldn /var/run/docker.sock | cut -d' ' -f 4)
 groupmod -g $gid docker
-adduser --system --no-create-home app
-getent group docker
-getent passwd app

--- a/dind/readme.md
+++ b/dind/readme.md
@@ -1,0 +1,24 @@
+# Docker-in-Docker (out of Docker)
+
+Base image for tools / experiments with containers talking to their
+host's Docker daemon.
+
+When running, you'd want to mount a volume with the host's
+`/var/run/docker.sock` (or equivalent):
+
+    docker run -ti --rm \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        unit9/dind
+
+When overriding `rc.local` in your own image, remember to modify the
+container's `docker` group's GID to match host's:
+
+    gid=$(ls -ldn /var/run/docker.sock | cut -d' ' -f 4)
+    groupmod -g $gid docker
+
+When running the container with the shell as the entry point, you may
+want to run `/etc/rc.local` by hand.
+
+When running some service, remember to grant it group membership:
+
+    chpst -u nobody:docker some-app...

--- a/inspector/Dockerfile
+++ b/inspector/Dockerfile
@@ -4,7 +4,7 @@ maintainer Kamil Cholewinski <kamil.cholewinski@unit9.com>
 run apt-get update && \
     apt-get dist-upgrade --yes && \
     apt-get install --no-install-recommends --yes \
-            python-werkzeug \
+            python-flask \
             && \
     rm -rf /var/cache/apt /var/lib/apt/lists/
 

--- a/inspector/Dockerfile
+++ b/inspector/Dockerfile
@@ -1,22 +1,13 @@
-from unit9/base:latest
+from unit9/dind:latest
 maintainer Kamil Cholewinski <kamil.cholewinski@unit9.com>
 
-run apt-key adv \
-    --keyserver hkp://ha.pool.sks-keyservers.net:80 \
-    --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-run echo 'deb https://apt.dockerproject.org/repo debian-jessie main' \
-     > /etc/apt/sources.list.d/docker.list
 run apt-get update && \
     apt-get dist-upgrade --yes && \
     apt-get install --no-install-recommends --yes \
-            docker-engine \
             python-werkzeug \
             && \
     rm -rf /var/cache/apt /var/lib/apt/lists/
 
-volume /var/run/docker.sock
-
 expose 8600
-add rc.local /etc/rc.local
 add run /etc/service/inspector/run
 add main.py /app/main.py

--- a/inspector/Dockerfile
+++ b/inspector/Dockerfile
@@ -1,0 +1,22 @@
+from unit9/base:latest
+maintainer Kamil Cholewinski <kamil.cholewinski@unit9.com>
+
+run apt-key adv \
+    --keyserver hkp://ha.pool.sks-keyservers.net:80 \
+    --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+run echo 'deb https://apt.dockerproject.org/repo debian-jessie main' \
+     > /etc/apt/sources.list.d/docker.list
+run apt-get update && \
+    apt-get dist-upgrade --yes && \
+    apt-get install --no-install-recommends --yes \
+            docker-engine \
+            python-werkzeug \
+            && \
+    rm -rf /var/cache/apt /var/lib/apt/lists/
+
+volume /var/run/docker.sock
+
+expose 8600
+add rc.local /etc/rc.local
+add run /etc/service/inspector/run
+add main.py /app/main.py

--- a/inspector/main.py
+++ b/inspector/main.py
@@ -8,11 +8,13 @@ import sys
 import urlparse
 import wsgiref.handlers
 
-import werkzeug
-import werkzeug.serving
+import flask
 
 
-logging.basicConfig(level=logging.DEBUG)
+app = flask.Flask(__name__)
+app.debug = int(os.environ.get("DEBUG", "0"))
+app.logger.setLevel(logging.DEBUG)
+app.logger.addHandler(logging.StreamHandler())
 
 
 def getoutput(cmd):
@@ -29,6 +31,37 @@ def getoutput(cmd):
     return out
 
 
+def docker_list_containers():
+    lines = getoutput([
+        "docker", "ps", "-a",
+        "--format", "{{.ID}}\x1f{{.Names}}\x1f{{.Image}}",
+    ]).strip().split("\n")
+    data = [line.split("\x1f", 2) for line in lines]
+    return [{"id": id, "names": names.split(","), "image": image}
+                   for id, names, image in data]
+
+
+def docker_inspect_containers(*containers):
+    try:
+        return json.loads(getoutput([
+            "docker", "inspect", "--type", "container",
+        ] + list(containers)))
+    except RuntimeError as e:
+        if e.args[0] == 1:
+            return []
+        raise
+
+
+def docker_inspect_image_tags(image):
+    rawtags = getoutput([
+        "docker", "inspect", "--type", "image",
+        "-f", r'{{ range .RepoTags }}{{ printf "%s\n" .}}{{ end }}',
+        image,
+    ]).strip().split()
+    return [{"repository": repository, "tag": tag}
+            for repository, tag in map(lambda s: s.split(":"), rawtags)]
+
+
 def response(status=200, headers=None, data=None, message=None):
     if data is None:
         data = {}
@@ -43,39 +76,57 @@ def response(status=200, headers=None, data=None, message=None):
     )
 
 
-@werkzeug.wrappers.Request.application
-def application(request):
-    if request.path != "/":
-        return response(404)
-    if request.method != "GET":
-        return response(405)
-    query = dict(urlparse.parse_qsl(request.query_string))
-    try:
-        container = query["container"]
-    except LookupError:
-        return response(400, message="required parameter: container")
-    try:
-        image = getoutput([
-            "docker", "inspect", "--type", "container",
-            "-f", "{{.Config.Image}}", container,
-        ]).strip()
-    except RuntimeError as e:
-        if e.args[0] == 1:
-            return response(404)
-        raise
-    tags = getoutput([
-        "docker", "inspect", "--type", "image",
-        "-f", r'{{ range .RepoTags }}{{ printf "%s\n" .}}{{ end }}',
-        image,
+@app.route("/")
+def index():
+    client, server = getoutput([
+        "docker", "version",
+        "-f", "{{ .Client.Version }} {{ .Server.Version }}",
     ]).strip().split()
-    return response(data={"image": image, "tags": tags})
+    return flask.jsonify(
+        message="Hello",
+        version=dict(client=client, server=server),
+    )
+
+
+@app.route("/whoami")
+def get_whoami():
+    ip = flask.request.remote_addr
+    containers = docker_list_containers()
+    name = None
+    image = None
+    tags = []
+    for container in containers:
+        for container in docker_inspect_containers(*container["names"]):
+            if container["NetworkSettings"]["IPAddress"] == ip:
+                name = container["Name"].lstrip("/")
+                image = container["Config"]["Image"]
+                tags = docker_inspect_image_tags(image)
+                break
+    return flask.jsonify(ip=ip, name=name, image=image, tags=tags)
+
+
+@app.route("/containers")
+def list_containers():
+    containers = docker_list_containers()
+    return flask.jsonify(containers=containers)
+
+
+@app.route("/containers/<string:container>")
+def get_container(container):
+    containers = docker_inspect_containers(container)
+    if not containers:
+        return flask.abort(404)
+    image = containers[0]["Config"]["Image"]
+    tags = docker_inspect_image_tags(image)
+    return flask.jsonify(image=image, tags=tags, name=container)
 
 
 if __name__ == "__main__":
     if os.environ.get("REQUEST_METHOD"):
-        wsgiref.handlers.CGIHandler().run(application)
+        wsgiref.handlers.CGIHandler().run(app.wsgi_app)
     else:
+        import werkzeug.serving
         werkzeug.serving.run_simple(
             os.environ.get("HOST", "localhost"),
             int(os.environ.get("PORT", "8600")),
-            application)
+            app.wsgi_app)

--- a/inspector/main.py
+++ b/inspector/main.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import urlparse
+import wsgiref.handlers
+
+import werkzeug
+import werkzeug.serving
+
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def getoutput(cmd):
+    p = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+    p.stdin.close()
+    out = p.stdout.read()
+    status = p.wait()
+    if status != 0:
+        raise RuntimeError(status)
+    return out
+
+
+def response(status=200, headers=None, data=None, message=None):
+    if data is None:
+        data = {}
+    data.setdefault("status", status)
+    if message:
+        data.setdefault("message", message)
+    return werkzeug.wrappers.Response(
+        response=json.dumps(data, indent=4, sort_keys=True),
+        status=202,
+        headers=headers,
+        mimetype="application/json"
+    )
+
+
+@werkzeug.wrappers.Request.application
+def application(request):
+    if request.path != "/":
+        return response(404)
+    if request.method != "GET":
+        return response(405)
+    query = dict(urlparse.parse_qsl(request.query_string))
+    try:
+        container = query["container"]
+    except LookupError:
+        return response(400, message="required parameter: container")
+    try:
+        image = getoutput([
+            "docker", "inspect", "--type", "container",
+            "-f", "{{.Config.Image}}", container,
+        ]).strip()
+    except RuntimeError as e:
+        if e.args[0] == 1:
+            return response(404)
+        raise
+    tags = getoutput([
+        "docker", "inspect", "--type", "image",
+        "-f", r'{{ range .RepoTags }}{{ printf "%s\n" .}}{{ end }}',
+        image,
+    ]).strip().split()
+    return response(data={"image": image, "tags": tags})
+
+
+if __name__ == "__main__":
+    if os.environ.get("REQUEST_METHOD"):
+        wsgiref.handlers.CGIHandler().run(application)
+    else:
+        werkzeug.serving.run_simple(
+            os.environ.get("HOST", "localhost"),
+            int(os.environ.get("PORT", "8600")),
+            application)

--- a/inspector/rc.local
+++ b/inspector/rc.local
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+gid=$(ls -ldn /var/run/docker.sock | cut -d' ' -f 4)
+groupmod -g $gid docker
+adduser --system --no-create-home app
+getent group docker
+getent passwd app

--- a/inspector/readme.md
+++ b/inspector/readme.md
@@ -1,0 +1,31 @@
+# Inspector
+
+Inspector exposes a simple API to query running containers' images and
+tags.
+
+Build it:
+
+    docker build -t unit9/inspector .
+
+Run it:
+
+    docker run -ti --rm \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -p 8600:8600 --name inspectme inspector
+
+Probe it:
+
+    $ curl localhost:8600?container=inspectme
+    {
+        "status": 200,
+        "image": "unit9/inspector",
+        "tags": [
+            "unit9/inspector:latest"
+        ]
+    }
+
+Use with `jq` and `cut`:
+
+    $ curl -s localhost:8600?container=inspectme | jq -r .tags[] \
+        | cut -d: -f2
+    latest

--- a/inspector/readme.md
+++ b/inspector/readme.md
@@ -3,6 +3,8 @@
 Inspector exposes a simple API to query running containers' images and
 tags.
 
+## Quickstart
+
 Build it:
 
     docker build -t unit9/inspector .
@@ -11,21 +13,95 @@ Run it:
 
     docker run -ti --rm \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        -p 8600:8600 --name inspectme inspector
+        -p 8600:8600 --name inspector unit9/inspector
 
 Probe it:
 
-    $ curl localhost:8600?container=inspectme
+    $ docker run -ti --rm --link inspector \
+          --name shell --hostname shell unit9/base bash
+    root@shell:/# curl inspector:8600/whoami
     {
-        "status": 200,
-        "image": "unit9/inspector",
-        "tags": [
-            "unit9/inspector:latest"
-        ]
+      "image": "unit9/base",
+      "ip": "172.17.0.3",
+      "name": "shell",
+      "tags": [
+        {
+          "repository": "unit9/base",
+          "tag": "latest"
+        }
+      ]
     }
 
-Use with `jq` and `cut`:
+Use with `jq`:
 
-    $ curl -s localhost:8600?container=inspectme | jq -r .tags[] \
-        | cut -d: -f2
+    root@shell:/# curl -s inspector:8600/whoami | jq -r .tags[].tag
     latest
+
+## API reference
+
+### GET /
+
+Returns a greeting, and Docker server/client versions:
+
+    {
+      "message": "Hello",
+      "version": {
+        "client": "1.12.5",
+        "server": "1.12.5"
+      }
+    }
+
+### GET /whoami
+
+Tries to match requester's IP address to any running containers, and
+inspects the matching container:
+
+    {
+      "image": "unit9/base", 
+      "ip": "172.17.0.3", 
+      "name": "desperate_newton", 
+      "tags": [
+        {
+          "repository": "unit9/base", 
+          "tag": "latest"
+        }
+      ]
+    }
+
+### GET /containers
+
+Lists running containers:
+
+    {
+      "containers": [
+          {
+          "id": "6e85cf044d7e", 
+          "image": "unit9/base", 
+          "names": [
+            "shell"
+          ]
+        },
+        {
+          "id": "07c92bed3b3c", 
+          "image": "unit9/inspector", 
+          "names": [
+            "inspector"
+          ]
+        }
+      ]
+    }
+
+### GET /containers/<name>
+
+Inspects the named container (format identical to `whoami`):
+
+    {
+      "image": "unit9/inspector", 
+      "name": "inspector", 
+      "tags": [
+        {
+          "repository": "unit9/inspector", 
+          "tag": "latest"
+        }
+      ]
+    }

--- a/inspector/run
+++ b/inspector/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+cd /app
+exec env HOME=/tmp HOST=0.0.0.0 chpst -u app:docker python main.py

--- a/inspector/run
+++ b/inspector/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 cd /app
-exec env HOME=/tmp HOST=0.0.0.0 chpst -u app:docker python main.py
+exec env HOME=/tmp HOST=0.0.0.0 chpst -u nobody:docker python main.py


### PR DESCRIPTION
Adds an inspector image, to expose container&image metadata to running containers.

(E.g. to display version numbers inside running webapps without having to embed tag metadata at build time, allowing images to be tagged without a rebuild.)

Also adds an image for Docker-in-Docker kind of services, perhaps useful in future experiments.

Probably won't work on Kubernetes - didn't try.