### PR TITLE
[base] Add socklog; fix readme

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
             ca-certificates \
             curl \
             runit \
+            socklog \
             && \
     rm -rf /var/cache/apt /var/lib/apt/lists
 
@@ -20,4 +21,5 @@ RUN curl -fsSL -o /tmp/runsvinit.tgz \
     && chown root:root /sbin/runsvinit \
     && rm /tmp/runsvinit.tgz
 ADD rc rc.local /etc/
+ADD socklog.run /etc/service/socklog/run
 CMD ["/etc/rc"]

--- a/base/readme.md
+++ b/base/readme.md
@@ -15,10 +15,14 @@ written by Peter Bourgon and hosted on Github,
 
 Service supervision is handled with [runit][].
 
-Source on [Github][]: <https://github.com/unit9/docker-base>
+Programs that insist on logging to [syslog][] are handled with
+[socklog][].
+
+Source on Github: <https://github.com/unit9/docklabs>
 
 [runit]: http://smarden.org/runit/
-[Github]: https://github.com/
+[socklog]: http://smarden.org/socklog/
+[syslog]: https://en.wikipedia.org/wiki/syslog
 
 ## Features and non-features
 

--- a/base/socklog.run
+++ b/base/socklog.run
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+exec chpst -U log socklog


### PR DESCRIPTION
Some packages just *insist* on logging to syslog. We make them easier to
deal with, by running a simple syslog service that prints syslogged
stuff to stdout (and allows Docker to consume it).

Also fix readme.