### PR TITLE
[common.mk] refactor shell; add ${DOCKERFILE}

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -5,7 +5,11 @@ VENDOR  ?= unit9
 VERSION ?= latest
 IMAGE   ?= ${VENDOR}/${NAME}
 
+DOCKERFILE ?= Dockerfile
+
 DOCKER_RUN_ARGS ?=
+DOCKER_RUN_CMD	?=
+DOCKER_SH_CMD	?= bash
 
 all: build
 
@@ -16,9 +20,9 @@ options:
 	@echo "VERSION	= ${VERSION}"
 	@echo "DOCKER_RUN_ARGS	= ${DOCKER_RUN_ARGS}"
 
-build: Dockerfile
+build: ${DOCKERFILE}
 	@echo "BUILD ${IMAGE}:${VERSION}"
-	@docker build -t ${IMAGE}:${VERSION} .
+	@docker build -f ${DOCKERFILE} -t ${IMAGE}:${VERSION} .
 
 clean:
 	@echo "RMI ${IMAGE}:${VERSION}"
@@ -31,17 +35,11 @@ run:
 		--name ${NAME} \
 		--hostname ${NAME} \
 		${DOCKER_RUN_ARGS} \
-		${IMAGE}:${VERSION}
+		${IMAGE}:${VERSION} \
+		${DOCKER_RUN_CMD}
 
 shell:
-	@echo "RUN ${IMAGE}:${VERSION}"
-	@docker run \
-		--rm -ti \
-		--name ${NAME} \
-		--hostname ${NAME} \
-		${DOCKER_RUN_ARGS} \
-		${IMAGE}:${VERSION} \
-		bash
+	@ DOCKER_RUN_CMD=${DOCKER_SH_CMD} ${MAKE} run
 
 push:
 	@echo "PUSH ${IMAGE}:${VERSION}"


### PR DESCRIPTION
- Unifies `shell` and `run` targets
- Makes shell configurable - for those Alpine / busybox images
- Makes Dockerfile path configurable - in case we'd want more than one Dockerfile in a subdir (shared build context)

Last thing is usable like this... Suppose we have `nginx` 1.6 in Jessie, and 1.10 in backports. We'd need two very similar Dockerfiles and a shared build context for stuff like `nginx.conf`.

- Dockerfile-1.6
- Dockerfile-1.10

Then `Makefile` could include sth like this:

```makefile
NAME ?= nginx
VERSION ?= 1.6
DOCKERFILE = Dockerfile-${VERSION}
include ../common.mk
```

Not sure if the last thing is extremely useful, but I'm using it on some personal projects :)