### PR TITLE
Add option to use Postgres

### DIFF
--- a/arachni/Dockerfile
+++ b/arachni/Dockerfile
@@ -10,9 +10,13 @@ RUN cd /tmp \
     && curl -LO https://github.com/Arachni/arachni/releases/download/v1.5.1/arachni-1.5.1-0.5.12-linux-x86_64.tar.gz \
     && tar xzvf arachni-1.5.1-0.5.12-linux-x86_64.tar.gz \
     && rm arachni-1.5.1-0.5.12-linux-x86_64.tar.gz \
-    && mv arachni-1.5.1-0.5.12 /app
+    && mv arachni-1.5.1-0.5.12 /app \
+    && rm /app/system/arachni-ui-web/config/environments/development.rb \
+    && rm /app/system/arachni-ui-web/config/environments/test.rb
 
+COPY rc.local /etc/rc.local
 COPY web.run /etc/service/arachni_web/run
 COPY api.run /etc/service/arachni_api/run
+COPY postgres_setup /app/bin/postgres_setup
 
 EXPOSE 7331 9292

--- a/arachni/postgres_setup
+++ b/arachni/postgres_setup
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -eu
+
+if [ -z ${PG_HOST+x} ] || [ -z ${PG_DATABASE+x} ] || [ -z ${PG_USERNAME+x} ] ||
+    [ -z ${PG_PASSWORD+x} ]; then
+    exit
+fi
+
+# (c) http://stackoverflow.com/a/35732641
+cat >/app/system/arachni-ui-web/lib/tasks/db_exists.rake <<EOL
+namespace :db do
+  desc "Checks to see if the database exists"
+  task :exists do
+    begin
+      Rake::Task['environment'].invoke
+      ActiveRecord::Base.connection
+    rescue
+      exit 1
+    else
+      exit 0
+    end
+  end
+end
+EOL
+
+cat >/app/system/arachni-ui-web/config/database.yml <<EOL
+production:
+  host: $PG_HOST
+  adapter: postgresql
+  encoding: unicode
+  database: $PG_DATABASE
+  pool: 50
+  username: $PG_USERNAME
+  password: $PG_PASSWORD
+EOL
+
+/app/bin/arachni_web_task db:exists || /app/bin/arachni_web_task db:setup

--- a/arachni/rc.local
+++ b/arachni/rc.local
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eu
+
+/app/bin/postgres_setup

--- a/arachni/readme.md
+++ b/arachni/readme.md
@@ -6,7 +6,30 @@ aimed towards helping penetration testers and administrators evaluate the
 security of modern web applications.
 
 Web and REST API services are started on ports `9292` and `7331` respectively.
-Backend is using the default SQLite database with the default
-[credentials](https://github.com/Arachni/arachni-ui-web/wiki/database). Do not
-forget to change. API is not using any authentication either so use NGINX or
-some other proxy to add authentication if needed.
+API is not using any authentication either so use NGINX or some other proxy to
+add authentication if needed.
+
+## Database
+
+By default if you do not pass any parameters to `docker run`, arachni will use
+local SQLite database. If you want to use Postgres, pass the following
+arguments:
+
+* PG_HOST
+* PG_DATABASE
+* PG_USERNAME
+* PG_PASSWORD
+
+For example:
+
+```
+docker run -d -p 9292:9292 -p 7331:7331 --name arachni \
+    -e PG_HOST=192.168.50.1 -e PG_DATABASE=arachni \
+    -e PG_USERNAME=postgres -e PG_PASSWORD=arachni \
+    unit9/arachni:latest
+```
+
+Arachni will try to connect to your Postgres instance and check if the database
+already exists, if not it will be created and the initial migrations applied.
+Use the default [credentials](https://github.com/Arachni/arachni-ui-web/wiki/database)
+to login.


### PR DESCRIPTION
Too much hassle to create a persistent disk for a tiny SQLite database and then setting up backups, etc. Also for production use author recommends postgres.