### PR TITLE
[nginx] Remove default vhost in kubenginx

### DIFF
--- a/kubenginx/nginx.conf
+++ b/kubenginx/nginx.conf
@@ -43,13 +43,5 @@ http {
     include /etc/nginx/resolver.conf;
     resolver_timeout 1s;
 
-    # Default vhost shows a 404 page
-    server {
-        listen 80 default;
-        server_name _;
-        default_type text/plain;
-        return 404 "404 Not Found\n";
-    }
-
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
Having a default vhost hardcoded in nginx.conf interferes with the ability to override it using a ConfigMap, which would be useful for things like redirects, health checks, etc.
