### PR TITLE
Add a simple self-check to the base image.

### DIFF
--- a/base/rc
+++ b/base/rc
@@ -2,5 +2,17 @@
 set -eu
 echo "Running /etc/rc.local"
 /etc/rc.local
+
+echo "Running self-checks"
+find /etc/service -type f -name run -not -perm /u=x |
+    while read fname
+    do
+        echo "FATAL: file does not have the u+x bit set: $fname"
+        echo "       Either use 'chmod +x', or rename the file."
+        echo "       Consult runit man pages for details:"
+        echo "       http://smarden.org/runit/"
+        exit 111
+    done
+
 echo "Running /sbin/runsvinit"
 exec /sbin/runsvinit


### PR DESCRIPTION
Unfortunately, people often forget the +x bit on `run` files. Let's be
helpful and avoid starting a container that will be broken anyway:

```
$ make build run
BUILD unit9/base:latest
Sending build context to Docker daemon  10.24kB
Step 1/7 : FROM debian:jessie
[... snip ...]
Successfully built b30a3fbc08d7
Successfully tagged unit9/base:latest
RUN unit9/base:latest
Running /etc/rc.local
Running self-checks
FATAL: file does not have the u+x bit set: /etc/service/socklog/run
       Either use 'chmod +x', or rename the file.
       Consult runit man pages for details:
       http://smarden.org/runit/
../common.mk:32: recipe for target 'run' failed
make: *** [run] Error 111
```